### PR TITLE
<feat>: implement store creation endpoint (POST /stores)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,18 @@ dotenv.config({ path: 'config.env' });
 
 import { NestFactory } from '@nestjs/core';
 import { StoresModule } from './stores/stores.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(StoresModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
+  
   await app.listen(process.env.PORT || 8000);
 }
 bootstrap();

--- a/src/stores/controllers/stores.controller.ts
+++ b/src/stores/controllers/stores.controller.ts
@@ -11,7 +11,7 @@ export class StoresController {
 
   @Get()
   async findAll(): Promise<{ stores: Store[]; limit: number; offset: number; total: number }> {
-    this.logger.log('Recebida requisição GET /stores');
+    this.logger.log('Request Received GET /stores');
 
     const stores = await this.storesService.getAllStores();
 

--- a/src/stores/controllers/stores.controller.ts
+++ b/src/stores/controllers/stores.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Logger } from '@nestjs/common';
+import { Body, Controller, Get, Logger, Post } from '@nestjs/common';
 import { StoresService } from '../services/stores.service';
 import { Store } from '../interfaces/store.interface';
+import { CreateStoreDto } from '../dto/create-store.dto';
 
 @Controller('stores')
 export class StoresController {
@@ -20,5 +21,11 @@ export class StoresController {
       offset: 1,
       total: stores.length,
     };
+  }
+
+  @Post()
+  async create(@Body() dto: CreateStoreDto): Promise<Store> {
+    this.logger.log(`POST /stores - Creating store: ${dto.storeName}`);
+    return this.storesService.createStore(dto);
   }
 }

--- a/src/stores/repositories/stores.repository.ts
+++ b/src/stores/repositories/stores.repository.ts
@@ -2,6 +2,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Injectable } from '@nestjs/common';
 import { Store } from '../interfaces/store.interface';
+import { CreateStoreDto } from '../dto/create-store.dto';
 
 @Injectable()
 export class StoresRepository {
@@ -10,4 +11,10 @@ export class StoresRepository {
   async findAll(): Promise<Store[]> {
     return this.storeModel.find().exec();
   }
+
+  async create(storeData: CreateStoreDto): Promise<Store> {
+    const createdStore = new this.storeModel(storeData);
+    return createdStore.save();
+  }
+  
 }

--- a/src/stores/services/stores.service.ts
+++ b/src/stores/services/stores.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { StoresRepository } from '../repositories/stores.repository';
 import { Store } from '../interfaces/store.interface';
+import { CreateStoreDto } from '../dto/create-store.dto';
 @Injectable()
 export class StoresService {
   private readonly logger = new Logger(StoresService.name);
@@ -13,4 +14,10 @@ export class StoresService {
     this.logger.log(`${stores.length} Stores`);
     return stores;
   }
+
+  async createStore(dto: CreateStoreDto): Promise<Store> {
+    this.logger.log(`Criando nova loja: ${dto.storeName}`);
+    return this.storesRepository.create(dto);
+  }
+  
 }


### PR DESCRIPTION
This pull request adds a new feature to the Physical-Store API:

✅ Created a POST /stores endpoint that allows the creation of new store entries.

Changes included:
- Service method to handle store creation with Winston logger
- Repository function to persist data to MongoDB
- Global validation pipe configured to whitelist allowed fields
- Logging of request details for auditing

This feature is a key step toward enabling the dynamic registration of stores for future delivery calculations.

Next step: implement route to find stores by CEP with delivery logic (Correios).

✅ Tested with Postman and confirmed store is saved to MongoDB successfully.
